### PR TITLE
Add name and description filtering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    notion_to_html (1.0.0)
+    notion_to_html (1.1.0)
       actionview (~> 7, >= 7.0.0)
       activesupport (~> 7, >= 7.0.0)
       dry-configurable (~> 1.2)

--- a/lib/notion_to_html/version.rb
+++ b/lib/notion_to_html/version.rb
@@ -2,5 +2,5 @@
 
 module NotionToHtml
   # The current version of the NotionToHtml gem.
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/notion_to_html/service_spec.rb
+++ b/spec/notion_to_html/service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe NotionToHtml::Service do
   end
 
   describe '#default_query' do
-    context 'when no slug or tag is provided' do
+    context 'when no name or description or slug or tag is provided' do
       it 'returns the default query' do
         expected_query = [
           {
@@ -40,6 +40,40 @@ RSpec.describe NotionToHtml::Service do
           }
         ]
         expect(service.default_query(slug: slug)).to eq(expected_query)
+      end
+    end
+
+    context 'when a name is provided' do
+      it 'includes the name in the query' do
+        name = 'example-name'
+        expected_query = [
+          {
+            property: 'public',
+            checkbox: { equals: true }
+          },
+          {
+            property: 'name',
+            rich_text: { contains: name }
+          }
+        ]
+        expect(service.default_query(name: name)).to eq(expected_query)
+      end
+    end
+
+    context 'when a description is provided' do
+      it 'includes the description in the query' do
+        description = 'example-description'
+        expected_query = [
+          {
+            property: 'public',
+            checkbox: { equals: true }
+          },
+          {
+            property: 'description',
+            rich_text: { contains: description }
+          }
+        ]
+        expect(service.default_query(description: description)).to eq(expected_query)
       end
     end
 
@@ -79,6 +113,28 @@ RSpec.describe NotionToHtml::Service do
           }
         ]
         expect(service.default_query(slug: slug, tag: tag)).to eq(expected_query)
+      end
+    end
+
+    context 'when both name and description are provided' do
+      it 'includes both the name and description in the query' do
+        name = 'example-name'
+        description = 'example-description'
+        expected_query = [
+          {
+            property: 'public',
+            checkbox: { equals: true }
+          },
+          {
+            property: 'name',
+            rich_text: { contains: name }
+          },
+          {
+            property: 'description',
+            rich_text: { contains: description }
+          }
+        ]
+        expect(service.default_query(name: name, description: description)).to eq(expected_query)
       end
     end
   end


### PR DESCRIPTION
The default and expected notion database has `name` & `description` properties.

This PR aims to add the ability to filter by name and description with a fuzzy search.

Bumps minor version to 1.1.0