### PR TITLE
Fix name filtering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    notion_to_html (1.1.0)
+    notion_to_html (1.1.1)
       actionview (~> 7, >= 7.0.0)
       activesupport (~> 7, >= 7.0.0)
       dry-configurable (~> 1.2)

--- a/lib/notion_to_html/service.rb
+++ b/lib/notion_to_html/service.rb
@@ -37,9 +37,7 @@ module NotionToHtml
         if name
           query.push({
             property: 'name',
-            rich_text: {
-              contains: name
-            }
+            contains: name
           })
         end
 

--- a/lib/notion_to_html/version.rb
+++ b/lib/notion_to_html/version.rb
@@ -2,5 +2,5 @@
 
 module NotionToHtml
   # The current version of the NotionToHtml gem.
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/notion_to_html/service_spec.rb
+++ b/spec/notion_to_html/service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe NotionToHtml::Service do
           },
           {
             property: 'name',
-            rich_text: { contains: name }
+            contains: name
           }
         ]
         expect(service.default_query(name: name)).to eq(expected_query)
@@ -127,7 +127,7 @@ RSpec.describe NotionToHtml::Service do
           },
           {
             property: 'name',
-            rich_text: { contains: name }
+            contains: name
           },
           {
             property: 'description',


### PR DESCRIPTION
Given the default databse structure `name` is a Title filed, not a rich_text field, so we have to change the query to acomodate that.