### PR TITLE
Fix filtering logic conditions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    notion_to_html (1.1.2)
+    notion_to_html (1.1.3)
       actionview (~> 7, >= 7.0.0)
       activesupport (~> 7, >= 7.0.0)
       dry-configurable (~> 1.2)

--- a/lib/notion_to_html/service.rb
+++ b/lib/notion_to_html/service.rb
@@ -24,33 +24,7 @@ module NotionToHtml
             }
           }
         ]
-
-        if slug
-          query.push({
-            property: 'slug',
-            rich_text: {
-              equals: slug
-            }
-          })
-        end
-
-        if name
-          query.push({
-            property: 'name',
-            title: {
-              contains: name
-            }
-          })
-        end
-
-        if description
-          query.push({
-            property: 'description',
-            rich_text: {
-              contains: description
-            }
-          })
-        end
+        or_query = []
 
         if tag
           query.push({
@@ -61,6 +35,34 @@ module NotionToHtml
           })
         end
 
+        if slug
+          or_query.push({
+            property: 'slug',
+            rich_text: {
+              equals: slug
+            }
+          })
+        end
+
+        if name
+          or_query.push({
+            property: 'name',
+            title: {
+              contains: name
+            }
+          })
+        end
+
+        if description
+          or_query.push({
+            property: 'description',
+            rich_text: {
+              contains: description
+            }
+          })
+        end
+
+        query.push('or': or_query) unless or_query.blank?
         query
       end
 

--- a/lib/notion_to_html/version.rb
+++ b/lib/notion_to_html/version.rb
@@ -2,5 +2,5 @@
 
 module NotionToHtml
   # The current version of the NotionToHtml gem.
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end

--- a/spec/notion_to_html/service_spec.rb
+++ b/spec/notion_to_html/service_spec.rb
@@ -35,8 +35,12 @@ RSpec.describe NotionToHtml::Service do
             checkbox: { equals: true }
           },
           {
-            property: 'slug',
-            rich_text: { equals: slug }
+            or: [
+              {
+                property: 'slug',
+                rich_text: { equals: slug }
+              }
+            ]
           }
         ]
         expect(service.default_query(slug: slug)).to eq(expected_query)
@@ -52,8 +56,12 @@ RSpec.describe NotionToHtml::Service do
             checkbox: { equals: true }
           },
           {
-            property: 'name',
-            title: { contains: name }
+            or: [
+              {
+                property: 'name',
+                title: { contains: name }
+              }
+            ]
           }
         ]
         expect(service.default_query(name: name)).to eq(expected_query)
@@ -69,8 +77,12 @@ RSpec.describe NotionToHtml::Service do
             checkbox: { equals: true }
           },
           {
-            property: 'description',
-            rich_text: { contains: description }
+            or: [
+              {
+                property: 'description',
+                rich_text: { contains: description }
+              }
+            ]
           }
         ]
         expect(service.default_query(description: description)).to eq(expected_query)
@@ -104,12 +116,16 @@ RSpec.describe NotionToHtml::Service do
             checkbox: { equals: true }
           },
           {
-            property: 'slug',
-            rich_text: { equals: slug }
-          },
-          {
             property: 'tags',
             multi_select: { contains: tag }
+          },
+          {
+            or: [
+              {
+                property: 'slug',
+                rich_text: { equals: slug }
+              }
+            ]
           }
         ]
         expect(service.default_query(slug: slug, tag: tag)).to eq(expected_query)
@@ -126,12 +142,16 @@ RSpec.describe NotionToHtml::Service do
             checkbox: { equals: true }
           },
           {
-            property: 'name',
-            title: { contains: name }
-          },
-          {
-            property: 'description',
-            rich_text: { contains: description }
+            or: [
+              {
+                property: 'name',
+                title: { contains: name }
+              },
+              {
+                property: 'description',
+                rich_text: { contains: description }
+              }
+            ]
           }
         ]
         expect(service.default_query(name: name, description: description)).to eq(expected_query)


### PR DESCRIPTION
It being an AND for name, description and slug the filter would only find an page that met the three clauses at the same time, so it had to share the same word for name, description and slug.

This PR moves them to an optional OR clause so the can match individually