### PR TITLE
Add video refresh to external links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp/
 # rspec failure tracking
 .rspec_status
 *.gem
+.aider*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    notion_to_html (1.2.1)
+    notion_to_html (1.3.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
       dry-configurable (~> 1.2)

--- a/bin/render.rb
+++ b/bin/render.rb
@@ -16,7 +16,7 @@ end
 module NotionToHtml
   class Service
     class << self
-      def default_query(tag: nil, slug: nil)
+      def default_query(name: nil, description: nil, tag: nil, slug: nil)
         [
           {
             property: 'public',

--- a/examples/get_pages.html
+++ b/examples/get_pages.html
@@ -11,7 +11,7 @@
       
         <a href="./get_page.html" class="inline-block mb-8 pb-4">
           <div>
-            <p class="">August 26, 2024</p>
+            <p class="">August 26, 2023</p>
             <h1 class="mb-4 mt-6 text-3xl font-semibold"><span>Test</span></h1>
             <p class=""><span>This is a test file with all the current Notion blocks in it</span></p>
           </div>

--- a/lib/notion_to_html/base_block.rb
+++ b/lib/notion_to_html/base_block.rb
@@ -73,66 +73,92 @@ module NotionToHtml
       define_method("data_for_#{block}") { |options| options.dig(block, :data) }
     end
 
-    # can you refactor render to make it more readable? AI!
-
     # Renders the block based on its type.
     # @param options [Hash] Additional options for rendering the block.
     # @return [String] The rendered block as HTML.
     def render(options = {})
-      remaining_options = options.dig(@type).except(:class, :data)
-      case @type
-      when 'paragraph'
-        render_paragraph(
-          rich_text, class: class_for_paragraph(options), data: data_for_paragraph(options), **remaining_options
-        )
-      when 'heading_1'
-        render_heading_1(
-          rich_text, class: class_for_heading_1(options), data: data_for_heading_1(options), **remaining_options
-        )
-      when 'heading_2'
-        render_heading_2(
-          rich_text, class: class_for_heading_2(options), data: data_for_heading_2(options), **remaining_options
-        )
-      when 'heading_3'
-        render_heading_3(
-          rich_text, class: class_for_heading_3(options), data: data_for_heading_3(options), **remaining_options
-        )
-      when 'table_of_contents'
-        render_table_of_contents
-      when 'bulleted_list_item'
-        render_bulleted_list_item(
-          rich_text, @siblings, @children, 0, class: class_for_bulleted_list_item(options),
-          data: data_for_bulleted_list_item(options), **remaining_options
-        )
-      when 'numbered_list_item'
-        render_numbered_list_item(
-          rich_text, @siblings, @children, 0, class: class_for_numbered_list_item(options),
-          data: data_for_numbered_list_item(options), **remaining_options
-        )
-      when 'quote'
-        render_quote(
-          rich_text, class: class_for_quote(options), data: data_for_quote(options), **remaining_options
-        )
-      when 'callout'
-        render_callout(
-          rich_text, icon, class: class_for_callout(options), data: data_for_callout(options), **remaining_options
-        )
-      when 'code'
-        render_code(
-          rich_text, class: class_for_code(options), data: data_for_code(options), **remaining_options,
-          language: @properties['language']
-        )
-      when 'image', 'embed'
-        render_image(
-          *multi_media, class: class_for_image(options), data: data_for_image(options), **remaining_options
-        )
-      when 'video'
-        render_video(
-          *multi_media, class: class_for_video(options), data: data_for_video(options), **remaining_options
-        )
-      else
-        'Unsupported block'
-      end
+      render_method = RENDERERS[@type]
+      return 'Unsupported block' unless render_method
+
+      send(render_method, build_render_options(options))
+    end
+
+    private
+
+    # Maps block types to their corresponding render methods
+    RENDERERS = {
+      'paragraph' => :render_paragraph_block,
+      'heading_1' => :render_heading_1_block,
+      'heading_2' => :render_heading_2_block,
+      'heading_3' => :render_heading_3_block,
+      'table_of_contents' => :render_table_of_contents_block,
+      'bulleted_list_item' => :render_bulleted_list_item_block,
+      'numbered_list_item' => :render_numbered_list_item_block,
+      'quote' => :render_quote_block,
+      'callout' => :render_callout_block,
+      'code' => :render_code_block,
+      'image' => :render_image_block,
+      'embed' => :render_image_block,
+      'video' => :render_video_block
+    }.freeze
+
+    # Builds render options for a block type
+    # @param options [Hash] The original options hash
+    # @return [Hash] Processed options for rendering
+    def build_render_options(options)
+      {
+        class: send("class_for_#{@type}", options),
+        data: send("data_for_#{@type}", options),
+        **options.dig(@type)&.except(:class, :data).to_h
+      }
+    end
+
+    def render_paragraph_block(options)
+      render_paragraph(rich_text, **options)
+    end
+
+    def render_heading_1_block(options)
+      render_heading_1(rich_text, **options)
+    end
+
+    def render_heading_2_block(options)
+      render_heading_2(rich_text, **options)
+    end
+
+    def render_heading_3_block(options)
+      render_heading_3(rich_text, **options)
+    end
+
+    def render_table_of_contents_block(_options)
+      render_table_of_contents
+    end
+
+    def render_bulleted_list_item_block(options)
+      render_bulleted_list_item(rich_text, @siblings, @children, 0, **options)
+    end
+
+    def render_numbered_list_item_block(options)
+      render_numbered_list_item(rich_text, @siblings, @children, 0, **options)
+    end
+
+    def render_quote_block(options)
+      render_quote(rich_text, **options)
+    end
+
+    def render_callout_block(options)
+      render_callout(rich_text, icon, **options)
+    end
+
+    def render_code_block(options)
+      render_code(rich_text, **options.merge(language: @properties['language']))
+    end
+
+    def render_image_block(options)
+      render_image(*multi_media, **options)
+    end
+
+    def render_video_block(options)
+      render_video(*multi_media, **options)
     end
 
     # Retrieves the rich text content of the block.

--- a/lib/notion_to_html/base_block.rb
+++ b/lib/notion_to_html/base_block.rb
@@ -73,38 +73,63 @@ module NotionToHtml
       define_method("data_for_#{block}") { |options| options.dig(block, :data) }
     end
 
+    # can you refactor render to make it more readable? AI!
+
     # Renders the block based on its type.
     # @param options [Hash] Additional options for rendering the block.
     # @return [String] The rendered block as HTML.
     def render(options = {})
+      remaining_options = options.dig(@type).except(:class, :data)
       case @type
       when 'paragraph'
-        render_paragraph(rich_text, class: class_for_paragraph(options), data: data_for_paragraph(options))
+        render_paragraph(
+          rich_text, class: class_for_paragraph(options), data: data_for_paragraph(options), **remaining_options
+        )
       when 'heading_1'
-        render_heading_1(rich_text, class: class_for_heading_1(options), data: data_for_heading_1(options))
+        render_heading_1(
+          rich_text, class: class_for_heading_1(options), data: data_for_heading_1(options), **remaining_options
+        )
       when 'heading_2'
-        render_heading_2(rich_text, class: class_for_heading_2(options), data: data_for_heading_2(options))
+        render_heading_2(
+          rich_text, class: class_for_heading_2(options), data: data_for_heading_2(options), **remaining_options
+        )
       when 'heading_3'
-        render_heading_3(rich_text, class: class_for_heading_3(options), data: data_for_heading_3(options))
+        render_heading_3(
+          rich_text, class: class_for_heading_3(options), data: data_for_heading_3(options), **remaining_options
+        )
       when 'table_of_contents'
         render_table_of_contents
       when 'bulleted_list_item'
-        render_bulleted_list_item(rich_text, @siblings, @children, 0, class: class_for_bulleted_list_item(options),
-          data: data_for_bulleted_list_item(options))
+        render_bulleted_list_item(
+          rich_text, @siblings, @children, 0, class: class_for_bulleted_list_item(options),
+          data: data_for_bulleted_list_item(options), **remaining_options
+        )
       when 'numbered_list_item'
-        render_numbered_list_item(rich_text, @siblings, @children, 0, class: class_for_numbered_list_item(options),
-          data: data_for_numbered_list_item(options))
+        render_numbered_list_item(
+          rich_text, @siblings, @children, 0, class: class_for_numbered_list_item(options),
+          data: data_for_numbered_list_item(options), **remaining_options
+        )
       when 'quote'
-        render_quote(rich_text, class: class_for_quote(options), data: data_for_quote(options))
+        render_quote(
+          rich_text, class: class_for_quote(options), data: data_for_quote(options), **remaining_options
+        )
       when 'callout'
-        render_callout(rich_text, icon, class: class_for_callout(options), data: data_for_callout(options))
+        render_callout(
+          rich_text, icon, class: class_for_callout(options), data: data_for_callout(options), **remaining_options
+        )
       when 'code'
-        render_code(rich_text, class: class_for_code(options), data: data_for_code(options),
-          language: @properties['language'])
+        render_code(
+          rich_text, class: class_for_code(options), data: data_for_code(options), **remaining_options,
+          language: @properties['language']
+        )
       when 'image', 'embed'
-        render_image(*multi_media, class: class_for_image(options), data: data_for_image(options))
+        render_image(
+          *multi_media, class: class_for_image(options), data: data_for_image(options), **remaining_options
+        )
       when 'video'
-        render_video(*multi_media, class: class_for_video(options), data: data_for_video(options))
+        render_video(
+          *multi_media, class: class_for_video(options), data: data_for_video(options), **remaining_options
+        )
       else
         'Unsupported block'
       end

--- a/lib/notion_to_html/base_block.rb
+++ b/lib/notion_to_html/base_block.rb
@@ -68,10 +68,15 @@ module NotionToHtml
       @properties = data[@type]
     end
 
+    RENDERERS = {}.with_indifferent_access
+
     BLOCK_TYPES.each do |block|
       define_method("class_for_#{block}") { |options| options.dig(block, :class) }
       define_method("data_for_#{block}") { |options| options.dig(block, :data) }
+      RENDERERS[block] = "render_#{block}_block".to_sym
     end
+
+    RENDERERS.freeze
 
     # Renders the block based on its type.
     # @param options [Hash] Additional options for rendering the block.
@@ -83,25 +88,6 @@ module NotionToHtml
       send(render_method, build_render_options(options))
     end
 
-    private
-
-    # Maps block types to their corresponding render methods
-    RENDERERS = {
-      'paragraph' => :render_paragraph_block,
-      'heading_1' => :render_heading_1_block,
-      'heading_2' => :render_heading_2_block,
-      'heading_3' => :render_heading_3_block,
-      'table_of_contents' => :render_table_of_contents_block,
-      'bulleted_list_item' => :render_bulleted_list_item_block,
-      'numbered_list_item' => :render_numbered_list_item_block,
-      'quote' => :render_quote_block,
-      'callout' => :render_callout_block,
-      'code' => :render_code_block,
-      'image' => :render_image_block,
-      'embed' => :render_image_block,
-      'video' => :render_video_block
-    }.freeze
-
     # Builds render options for a block type
     # @param options [Hash] The original options hash
     # @return [Hash] Processed options for rendering
@@ -109,8 +95,8 @@ module NotionToHtml
       {
         class: send("class_for_#{@type}", options),
         data: send("data_for_#{@type}", options),
-        **options.dig(@type)&.except(:class, :data).to_h
-      }
+        **options.with_indifferent_access.dig(@type)&.except(:class, :data).to_h
+      }.deep_symbolize_keys
     end
 
     def render_paragraph_block(options)

--- a/lib/notion_to_html/service.rb
+++ b/lib/notion_to_html/service.rb
@@ -133,6 +133,11 @@ module NotionToHtml
         results
       end
 
+      # can you add documentation to this function following the style of rdoc that the other functions have? AI!
+      def refresh_block?(block)
+        refresh_image? || refresh_video?
+      end
+
       # Determines if an image block needs to be refreshed based on its expiry time
       # @param data [Hash] The data of the image block
       # @return [Boolean] True if the image needs to be refreshed, false otherwise
@@ -141,6 +146,17 @@ module NotionToHtml
         return false unless data.dig('image', 'type') == 'file'
 
         expiry_time = data.dig('image', 'file', 'expiry_time')
+        expiry_time.to_datetime.past?
+      end
+
+      # Determines if a video block needs to be refreshed based on its expiry time
+      # @param data [Hash] The data of the video block
+      # @return [Boolean] True if the video needs to be refreshed, false otherwise
+      def refresh_video?(data)
+        return false unless data['type'] == 'video'
+        return false unless data.dig('video', 'type') == 'file'
+
+        expiry_time = data.dig('video', 'file', 'expiry_time')
         expiry_time.to_datetime.past?
       end
 

--- a/lib/notion_to_html/service.rb
+++ b/lib/notion_to_html/service.rb
@@ -111,7 +111,7 @@ module NotionToHtml
         parent_list_block_index = nil
         results = []
         blocks['results'].each_with_index do |block, index|
-          block = refresh_block(block['id']) if refresh_image?(block)
+          block = refresh_block(block['id']) if refresh_block?(block)
           base_block = NotionToHtml::BaseBlock.new(block)
           base_block.children = get_blocks(base_block.id) if base_block.has_children
           if %w[numbered_list_item].include? base_block.type

--- a/lib/notion_to_html/service.rb
+++ b/lib/notion_to_html/service.rb
@@ -133,9 +133,11 @@ module NotionToHtml
         results
       end
 
-      # can you add documentation to this function following the style of rdoc that the other functions have? AI!
+      # Determines if a block needs to be refreshed based on its type and expiry time
+      # @param block [Hash] The block data to check
+      # @return [Boolean] True if the block needs to be refreshed, false otherwise
       def refresh_block?(block)
-        refresh_image? || refresh_video?
+        refresh_image?(block) || refresh_video?(block)
       end
 
       # Determines if an image block needs to be refreshed based on its expiry time

--- a/lib/notion_to_html/version.rb
+++ b/lib/notion_to_html/version.rb
@@ -2,5 +2,5 @@
 
 module NotionToHtml
   # The current version of the NotionToHtml gem.
-  VERSION = '1.2.1'
+  VERSION = '1.3.1'
 end

--- a/spec/fixtures/notion_to_html/get_page.yml
+++ b/spec/fixtures/notion_to_html/get_page.yml
@@ -563,4 +563,76 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"object":"block","id":"a56ff39a-0099-4637-ae1e-57affc56e556","parent":{"type":"page_id","page_id":"373eebc8-bcd7-4992-a1b3-174d39a6e6d4"},"created_time":"2023-09-16T20:43:00.000Z","last_edited_time":"2023-09-16T20:43:00.000Z","created_by":{"object":"user","id":"b37246c7-12d2-47b5-829a-6f2116c13c4e"},"last_edited_by":{"object":"user","id":"b37246c7-12d2-47b5-829a-6f2116c13c4e"},"has_children":false,"archived":false,"in_trash":false,"type":"image","image":{"caption":[],"type":"file","file":{"url":"https://prod-files-secure.s3.us-west-2.amazonaws.com/fa824482-b6be-4ccc-b78d-81cf16252f2f/44fb7742-e092-4b6d-a501-41b532da8102/3_empanadas.gif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45HZZMZUHI%2F20240823%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20240823T235502Z&X-Amz-Expires=3600&X-Amz-Signature=571375721cea4e808505299d2a61d1bfe86e785ef4003ee21983301d10be2f80&X-Amz-SignedHeaders=host&x-id=GetObject","expiry_time":"2024-08-24T00:55:02.630Z"}},"request_id":"19cf7dd4-d7ee-4bc9-b15f-a74f0709143e"}'
   recorded_at: Fri, 23 Aug 2024 23:55:02 GMT
-recorded_with: VCR 6.2.0
+- request:
+    method: get
+    uri: https://api.notion.com/v1/blocks/336fece0-287f-47a9-8828-26d01a1e4b85
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Notion Ruby Client/1.2.2
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Notion-Version:
+      - '2022-02-22'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 31 Jan 2025 22:42:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 90ad36da2d53a771-EZE
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"918-LWDQFvCAN6oR6YUcWV2wO9/iZ5k"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Content-Security-Policy:
+      - default-src 'none'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Notion-Request-Id:
+      - 7a741fed-6dbe-4f53-8a4f-95d6d9e85bc1
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=mQoGi8fBNFy.eIhCRcZ6uftafWvtgTV3ie1Y.0Ss0PU-1738363340-1.0.1.1-wSUY1fCCu4THO4EL.ypjot_BiyP7M5cSSW8bj6muNF1rSKavznCPkj6dGtewXG8Cg0YMkM1Z3sgUfqqlxLPXlQ;
+        path=/; expires=Fri, 31-Jan-25 23:12:20 GMT; domain=.notion.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=QOdbjyW_dZGX0KPk3F3eie6MFIfpy6nNViOYi70dpO0-1738363340352-0.0.1.1-604800000;
+        path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"object":"block","id":"336fece0-287f-47a9-8828-26d01a1e4b85","parent":{"type":"page_id","page_id":"373eebc8-bcd7-4992-a1b3-174d39a6e6d4"},"created_time":"2023-09-16T22:30:00.000Z","last_edited_time":"2023-09-16T22:31:00.000Z","created_by":{"object":"user","id":"b37246c7-12d2-47b5-829a-6f2116c13c4e"},"last_edited_by":{"object":"user","id":"b37246c7-12d2-47b5-829a-6f2116c13c4e"},"has_children":false,"archived":false,"in_trash":false,"type":"video","video":{"caption":[],"type":"file","file":{"url":"https://prod-files-secure.s3.us-west-2.amazonaws.com/fa824482-b6be-4ccc-b78d-81cf16252f2f/dbc07c0f-f7db-420d-9ecd-af076f53fac6/Virtual_Background_for_Zoom_Mandalorian_Razor_Crest_Cockpit_with_The_Child_%28Baby_Yoda%29.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAZI2LB466ZYYZ5DRC%2F20250131%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250131T224220Z&X-Amz-Expires=3600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEL7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJIMEYCIQDxI61UN46EmdME6ElprW2DrVONoVzuzoW3RvMTQgdSTgIhAOrSQU1ueOZaHMKwMkpgEVNzMSHQiUXXyZTtOgtN2RoGKogECMf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQABoMNjM3NDIzMTgzODA1IgwbYx1gC2QT1yrXSpQq3ANFbzZmMK7LfcclwNNQAecZCXWnFPVkrkrtMUC0ykizhJIWtB3eolqaBI0cq14zrerYvE5DD2M6mI1IqiBy%2B61PwjJaYGGw94v353t%2B3QQCxCB8sbPv%2F6QH9EvxN%2B9e0Ll8I0Sl9aLDj9xMQhPz8rNvTk6Xpl2B8%2FSLk9u7vEyWo0wZOlIQ0g%2BATWh2ddCqn1V41TqVVUrawbU9FIAAoCier8OncsdbnWLD%2BteDb6Em5%2FeRT4DI7cbhmNKu8yWitmlzBh2coa%2Bbe9BIwoZuRHOfDdXRA8Jjh2IP1bTaCEhuCkYyWEogZfXxS9FRjsFcJ9czjLUrgSReBE1Tikaq0zwktx0KB%2FQmkU6OLeTrO1LH9YYjgD3r0GwQzBSY5xbOTtVBeei%2FLGBwlgFKbmlVvpedqWRmaqcErTPmgt9CCjCh%2FebugXuCp6qnUmxCi6CbES6bjFNj2HtqIyUtVwCXjNZ%2BQBuXjJDqZVRDqsiv036IFt6TjrTPwyKNG3r1K1hdj7YfndIfAOtWpLSx%2BX1liMIiwBmHwfoVzLyZlFd987XNUzzBYIYh3%2Bt13IARLkNiArtb%2BRuMWfOJY%2Fnj8RoT5qcFyqGz8PtlL%2BdN2Gv%2FntSc7cAMZRIIj%2BKnoFUCcDCGlfW8BjqkAYVfFE29yZ3X7mqY5AY%2Bxdz%2FN5NWwTcthE5Pt39vWfXKoja3gASOK3prZtRmXyzNWBhdamurhVDJVe2%2B8eLGkb%2BsvgZXIBrc2auin2drxti6MQIq%2Fpgk0iKMhjImN3TTQuoXxaM0XmXT1ca5JGbAvtWPcvD2sO3U1WjLJI%2FW1Zz9T5WqH3tVl7kXQ6GNo6PXZ%2B2eQSlFG4zuGkVLtTqiC9Ngc6yT&X-Amz-Signature=4d1b9668fef54c94198aa50189a631b527cfe2a7c14e24243090b221f638e899&X-Amz-SignedHeaders=host&x-id=GetObject","expiry_time":"2025-01-31T23:42:20.217Z"}},"request_id":"7a741fed-6dbe-4f53-8a4f-95d6d9e85bc1"}'
+  recorded_at: Fri, 31 Jan 2025 22:42:20 GMT
+recorded_with: VCR 6.3.1

--- a/spec/notion_to_html/base_block_spec.rb
+++ b/spec/notion_to_html/base_block_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# can you update this spec with the latest changes on the base_block file AI!
 require 'spec_helper'
 
 RSpec.describe NotionToHtml::BaseBlock do

--- a/spec/notion_to_html/base_block_spec.rb
+++ b/spec/notion_to_html/base_block_spec.rb
@@ -110,31 +110,224 @@ RSpec.describe NotionToHtml::BaseBlock do
         )
       )
     end
-    # can you create the test for each block type instead of doing it dynamically AI!
-    NotionToHtml::BaseBlock::BLOCK_TYPES.each do |block_type|
-      context "with #{block_type} block" do
-        let(:data) do
-          base_data.merge({
-            'type' => block_type.to_s,
-            block_type.to_s => {
-              'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
-            }
-          })
-        end
 
-        it "calls render_#{block_type}_block with correct options" do
-          block = described_class.new(data)
-          render_method = "render_#{block_type}_block"
+    context 'with paragraph block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'paragraph',
+          'paragraph' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
 
-          expect(block).to receive(render_method).with(
-            hash_including(
-              class: nil,
-              data: nil
-            )
-          )
+      it 'calls render_paragraph_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_paragraph_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
 
-          block.render
-        end
+    context 'with heading_1 block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'heading_1',
+          'heading_1' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
+
+      it 'calls render_heading_1_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_heading_1_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with heading_2 block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'heading_2',
+          'heading_2' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
+
+      it 'calls render_heading_2_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_heading_2_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with heading_3 block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'heading_3',
+          'heading_3' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
+
+      it 'calls render_heading_3_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_heading_3_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with bulleted_list_item block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'bulleted_list_item',
+          'bulleted_list_item' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
+
+      it 'calls render_bulleted_list_item_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_bulleted_list_item_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with numbered_list_item block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'numbered_list_item',
+          'numbered_list_item' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
+
+      it 'calls render_numbered_list_item_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_numbered_list_item_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with quote block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'quote',
+          'quote' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
+
+      it 'calls render_quote_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_quote_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with callout block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'callout',
+          'callout' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+          }
+        })
+      end
+
+      it 'calls render_callout_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_callout_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with code block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'code',
+          'code' => {
+            'rich_text' => [{ 'text' => { 'content' => 'Test' } }],
+            'language' => 'ruby'
+          }
+        })
+      end
+
+      it 'calls render_code_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_code_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with image block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'image',
+          'image' => {
+            'type' => 'file',
+            'file' => {
+              'url' => 'https://example.com/image.jpg',
+              'expiry_time' => '2024-12-31T00:00:00.000Z'
+            },
+            'caption' => [{ 'text' => { 'content' => 'Test caption' } }]
+          }
+        })
+      end
+
+      it 'calls render_image_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_image_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
+      end
+    end
+
+    context 'with video block' do
+      let(:data) do
+        base_data.merge({
+          'type' => 'video',
+          'video' => {
+            'type' => 'file',
+            'file' => {
+              'url' => 'https://example.com/video.mp4',
+              'expiry_time' => '2024-12-31T00:00:00.000Z'
+            },
+            'caption' => [{ 'text' => { 'content' => 'Test caption' } }]
+          }
+        })
+      end
+
+      it 'calls render_video_block with correct options' do
+        block = described_class.new(data)
+        expect(block).to receive(:render_video_block).with(
+          hash_including(class: nil, data: nil)
+        )
+        block.render
       end
     end
   end

--- a/spec/notion_to_html/base_block_spec.rb
+++ b/spec/notion_to_html/base_block_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# can you update this spec with the latest changes on the base_block file AI!
 require 'spec_helper'
 
 RSpec.describe NotionToHtml::BaseBlock do
@@ -74,7 +73,73 @@ RSpec.describe NotionToHtml::BaseBlock do
     end
   end
 
-  # can you generate specs for the render method following the testing convention found in this file? AI!
+  describe '#render' do
+    let(:options) do
+      {
+        paragraph: {
+          class: 'custom-para',
+          data: { test: 'value' },
+          extra: 'param'
+        }
+      }
+    end
+
+    it 'renders unsupported block type' do
+      data = base_data.merge({
+        'type' => 'unsupported_type',
+        'unsupported_type' => {}
+      })
+      block = described_class.new(data)
+      expect(block.render).to eq('Unsupported block')
+    end
+
+    it 'builds render options correctly' do
+      data = base_data.merge({
+        'type' => 'paragraph',
+        'paragraph' => {
+          'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+        }
+      })
+      block = described_class.new(data)
+      
+      expect(block).to receive(:render_paragraph_block).with(
+        hash_including(
+          class: 'custom-para',
+          data: { test: 'value' },
+          extra: 'param'
+        )
+      )
+      
+      block.render(options)
+    end
+
+    NotionToHtml::BaseBlock::BLOCK_TYPES.each do |block_type|
+      context "with #{block_type} block" do
+        let(:data) do
+          base_data.merge({
+            'type' => block_type.to_s,
+            block_type.to_s => {
+              'rich_text' => [{ 'text' => { 'content' => 'Test' } }]
+            }
+          })
+        end
+
+        it "calls render_#{block_type}_block with correct options" do
+          block = described_class.new(data)
+          render_method = "render_#{block_type}_block"
+          
+          expect(block).to receive(render_method).with(
+            hash_including(
+              class: nil,
+              data: nil
+            )
+          )
+          
+          block.render
+        end
+      end
+    end
+  end
 
   describe '#rich_text' do
     it 'returns empty array when no rich_text is present' do

--- a/spec/notion_to_html/base_block_spec.rb
+++ b/spec/notion_to_html/base_block_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe NotionToHtml::BaseBlock do
     end
   end
 
+  # can you generate specs for the render method following the testing convention found in this file? AI!
+
   describe '#rich_text' do
     it 'returns empty array when no rich_text is present' do
       data = base_data.merge({

--- a/spec/notion_to_html/base_block_spec.rb
+++ b/spec/notion_to_html/base_block_spec.rb
@@ -101,18 +101,16 @@ RSpec.describe NotionToHtml::BaseBlock do
         }
       })
       block = described_class.new(data)
-      
-      expect(block).to receive(:render_paragraph_block).with(
+
+      expect(block.send(:build_render_options, options)).to match(
         hash_including(
           class: 'custom-para',
           data: { test: 'value' },
           extra: 'param'
         )
       )
-      
-      block.render(options)
     end
-
+    # can you create the test for each block type instead of doing it dynamically AI!
     NotionToHtml::BaseBlock::BLOCK_TYPES.each do |block_type|
       context "with #{block_type} block" do
         let(:data) do
@@ -127,14 +125,14 @@ RSpec.describe NotionToHtml::BaseBlock do
         it "calls render_#{block_type}_block with correct options" do
           block = described_class.new(data)
           render_method = "render_#{block_type}_block"
-          
+
           expect(block).to receive(render_method).with(
             hash_including(
               class: nil,
               data: nil
             )
           )
-          
+
           block.render
         end
       end

--- a/spec/notion_to_html/service_spec.rb
+++ b/spec/notion_to_html/service_spec.rb
@@ -209,6 +209,7 @@ RSpec.describe NotionToHtml::Service do
 
     context 'when an image block is not expired' do
       before do
+        allow(service).to receive(:refresh_video?)
         allow(service).to receive(:refresh_image?).and_return(false)
         allow(service).to receive(:refresh_block).and_call_original
       end
@@ -221,11 +222,38 @@ RSpec.describe NotionToHtml::Service do
 
     context 'when an image block has expired' do
       before do
+        allow(service).to receive(:refresh_video?)
         allow(ActiveSupport::TimeWithZone).to receive(:past?).and_return(true)
         allow(service).to receive(:refresh_block).and_call_original
       end
 
       it 'refreshes the block for the image ', vcr: { cassette_name: 'get_blocks' } do
+        subject
+        expect(service).to have_received(:refresh_block).once
+      end
+    end
+
+    context 'when an video block is not expired' do
+      before do
+        allow(service).to receive(:refresh_image?)
+        allow(service).to receive(:refresh_video?).and_return(false)
+        allow(service).to receive(:refresh_block).and_call_original
+      end
+
+      it 'does not refresh the block for the video', vcr: { cassette_name: 'get_blocks' } do
+        subject
+        expect(service).not_to have_received(:refresh_block)
+      end
+    end
+
+    context 'when an video block has expired' do
+      before do
+        allow(service).to receive(:refresh_image?)
+        allow(ActiveSupport::TimeWithZone).to receive(:past?).and_return(true)
+        allow(service).to receive(:refresh_block).and_call_original
+      end
+
+      it 'refreshes the block for the video ', vcr: { cassette_name: 'get_blocks' } do
         subject
         expect(service).to have_received(:refresh_block).once
       end
@@ -250,6 +278,27 @@ RSpec.describe NotionToHtml::Service do
     it 'returns false for non-image types' do
       data['type'] = 'text'
       expect(service.refresh_image?(data)).to be false
+    end
+  end
+
+  describe '#refresh_video?' do
+    let(:data) { { 'type' => 'video', 'video' => { 'type' => 'file', 'file' => { 'expiry_time' => expiry_time } } } }
+    let(:expired_data) do
+      { 'type' => 'video', 'video' => { 'type' => 'file', 'file' => { 'expiry_time' => (Time.now + 1.week).iso8601 } } }
+    end
+    let(:expiry_time) { (Time.now - 1.hour).iso8601 }
+
+    it 'returns true if the video has expired' do
+      expect(service.refresh_video?(data)).to be true
+    end
+
+    it 'returns false if the video has not expired' do
+      expect(service.refresh_video?(expired_data)).to be false
+    end
+
+    it 'returns false for non-video types' do
+      data['type'] = 'text'
+      expect(service.refresh_video?(data)).to be false
     end
   end
 end


### PR DESCRIPTION
## Features
- Add `video_refresh?` so video blocks get auto refreshed when expired
## Fixes
- Options like `override_class` where not being properly propagated to render. 
  - Now any additional options to `class` & `data` are correctly propagated to renderers
- Fix render script to conform to latest methods signatures